### PR TITLE
Make some text inputs a bit better

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "AO3 Podfic Posting Helper",
     "description": "Autofill metadata to match a work you were inspired by",
-    "version": "2.1",
+    "version": "2.2",
     "manifest_version": 2,
     "browser_specific_settings": {
         "gecko": {

--- a/src/options.css
+++ b/src/options.css
@@ -41,3 +41,7 @@ section {
 .header-icon {
     margin-left: 4px;
 }
+
+textarea.code-editor-textarea {
+    font-family: 'Roboto Mono', Courier, monospace;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -179,7 +179,7 @@
                             data-mdc-auto-init="MDCRipple">
                             <div class="mdc-button__ripple"></div>
                             <i class="material-icons mdc-button__icon" aria-hidden="true">save</i>
-                            <span class="mdc-button__label">Save as default</span>
+                            <span class="mdc-button__label">Save</span>
                         </button>
                     </div>
                 </div>

--- a/src/options.html
+++ b/src/options.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="theming.css">
     <link rel="stylesheet" href="resources/material-icons.css">
     <link rel="stylesheet" href="resources/roboto.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono">
     <script src="resources/browser-polyfill.min.js"></script>
     <title>AO3 Podfic Posting Helper Extension Options</title>
 </head>
@@ -54,6 +55,9 @@
                         <dt><strong><code>${authors}</code></strong></dt>
                         <dd>A comma-separated list of the authors of the original work.</dd>
                     </dl>
+                    <p>
+                        This template does not support HTML.
+                    </p>
                     <label class="mdc-text-field mdc-text-field--filled mdc-text-field--textarea"
                         data-mdc-auto-init="MDCTextField">
                         <span class="mdc-text-field__ripple"></span>
@@ -105,13 +109,19 @@
                         <dd>A comma-separated list of the authors of the original work. Each author is a link
                             to their AO3 page.</dd>
                     </dl>
+                    <p>
+                        This template supports HTML.
+                        <a href="https://archiveofourown.org/faq/formatting-content-on-ao3-with-html?language_id=en#canihtml"
+                            target="_blank">Learn more about using HTML on AO3</a>
+                    </p>
                     <label class="mdc-text-field mdc-text-field--filled mdc-text-field--textarea"
                         data-mdc-auto-init="MDCTextField">
                         <span class="mdc-text-field__ripple"></span>
                         <span class="mdc-floating-label" id="summary_template_label">Summary template</span>
                         <span class="mdc-text-field__resizer">
-                            <textarea class="mdc-text-field__input" rows="5" cols="100"
-                                aria-labelledby="summary_template_label" id="summary_template" required></textarea>
+                            <textarea class="mdc-text-field__input code-editor-textarea" rows="5" cols="100"
+                                aria-labelledby="summary_template_label" id="summary_template" required
+                                spellcheck="false"></textarea>
                         </span>
                         <span class="mdc-line-ripple"></span>
                     </label>
@@ -153,11 +163,17 @@
                         <span class="mdc-text-field__ripple"></span>
                         <span class="mdc-floating-label" id="default_body_label">Work template</span>
                         <span class="mdc-text-field__resizer">
-                            <textarea class="mdc-text-field__input" rows="20" cols="100"
-                                aria-labelledby="default_body_label" id="default_body" required></textarea>
+                            <textarea class="mdc-text-field__input code-editor-textarea" rows="20" cols="100"
+                                aria-labelledby="default_body_label" id="default_body" required
+                                spellcheck="false"></textarea>
                         </span>
                         <span class="mdc-line-ripple"></span>
                     </label>
+                    <p>
+                        This template supports HTML.
+                        <a href="https://archiveofourown.org/faq/formatting-content-on-ao3-with-html?language_id=en#canihtml"
+                            target="_blank">Learn more about using HTML on AO3</a>
+                    </p>
                     <div class="mdc-card__actions actions">
                         <button class="mdc-button mdc-button--raised mdc-card__action" type="submit"
                             data-mdc-auto-init="MDCRipple">

--- a/src/popup.html
+++ b/src/popup.html
@@ -51,10 +51,10 @@
                         data-mdc-auto-init="MDCTextField">
                         <span class="mdc-text-field__ripple"></span>
                         <span class="mdc-floating-label" id="url-label">URL of work to import from</span>
-                        <input class="mdc-text-field__input" type="text" aria-labelledby="url-label" id="url-input"
+                        <input class="mdc-text-field__input" type="url" aria-labelledby="url-label" id="url-input"
                             required aria-controls="url-error-hint" aria-describedby="url-error-hint"
                             pattern="https://archiveofourown.org/works/[0-9]+(/chapters/[0-9]+)?(/?)|https://archiveofourown.org/collections/.*/works/[0-9]+(/?)"
-                            title="Must be an AO3 work URL" name="ao3-url">
+                            title="Must be an AO3 work URL" name="ao3-url" spellcheck="false">
                         <span class="mdc-line-ripple"></span>
                     </label>
                     <div class="mdc-text-field-helper-line">


### PR DESCRIPTION
### Popup

- URL text input is now of type "url"
- URL input forces spell checking off

### Options

- Summary and work templates text areas now
   - Use monospace font
   - Disable spell checking
   - Have a link to the AO3 HTML documentation
- Title template explicitly states that HTML is not supported