### PR TITLE
Add more templating options

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -85,20 +85,25 @@
    * @param authors {Map<string,string>}
    * @returns
    */
-  function transformSummary(template, summary, title, url, authors) {
-    const titleText = link(url, title);
-    const authorsText =
-        Array.from(authors)
-            .map(([author, authorUrl]) => (link(authorUrl, author)))
-            .join(', ');
-    const blockSummaryText = '<blockquote>' + summary + '</blockquote>';
+  function transformHtmlTemplate(template, summary, title, url, authors) {
+    const titleLink = link(url, title);
+    const authorsLinks = Array.from(authors)
+      .map(([author, authorUrl]) => link(authorUrl, author))
+      .join(", ");
+    const authorsText = Array.from(authors)
+      .map(([author, authorUrl]) => author)
+      .join(", ");
+    const blockSummaryText = "<blockquote>" + summary + "</blockquote>";
 
     let newSummary = template;
-    newSummary = newSummary.replaceAll('${blocksummary}', blockSummaryText);
-    newSummary = newSummary.replaceAll('${summary}', summary);
-    newSummary = newSummary.replaceAll('${title}', titleText);
-    newSummary = newSummary.replaceAll('${authors}', authorsText);
-    newSummary = newSummary.replaceAll('${author}', authorsText);
+    newSummary = newSummary.replaceAll("${blocksummary}", blockSummaryText);
+    newSummary = newSummary.replaceAll("${summary}", summary);
+    newSummary = newSummary.replaceAll("${title}", titleLink);
+    newSummary = newSummary.replaceAll("${title-unlinked}", title);
+    newSummary = newSummary.replaceAll("${authors}", authorsLinks);
+    newSummary = newSummary.replaceAll("${author}", authorsLinks);
+    newSummary = newSummary.replaceAll("${authors-unlinked}", authorsText);
+    newSummary = newSummary.replaceAll("${author-unlinked}", authorsText);
 
     return newSummary;
   }
@@ -116,13 +121,17 @@
    * @returns
    */
   function transformTitle(template, title, authors) {
-    const authorsText =
-        Array.from(authors).map(([author, authorUrl]) => (author)).join(', ');
+    const authorsText = Array.from(authors)
+      .map(([author, authorUrl]) => author)
+      .join(", ");
 
     let newTitle = template;
-    newTitle = newTitle.replaceAll('${title}', title);
-    newTitle = newTitle.replaceAll('${authors}', authorsText);
-    newTitle = newTitle.replaceAll('${author}', authorsText);
+    newTitle = newTitle.replaceAll("${title}", title);
+    newTitle = newTitle.replaceAll("${title-unlinked}", title);
+    newTitle = newTitle.replaceAll("${authors}", authorsText);
+    newTitle = newTitle.replaceAll("${author}", authorsText);
+    newTitle = newTitle.replaceAll("${authors-unlinked}", authorsText);
+    newTitle = newTitle.replaceAll("${author-unlinked}", authorsText);
 
     return newTitle;
   }
@@ -136,14 +145,14 @@
    */
   function getTitleTemplate(titleOption, customTemplate) {
     switch (titleOption) {
-      case 'blank':
-        return '';
-      case 'orig':
-        return '${title}';
-      case 'custom':
+      case "blank":
+        return "";
+      case "orig":
+        return "${title}";
+      case "custom":
         return customTemplate;
       default:
-        return '[Podfic] ${title}';
+        return "[Podfic] ${title}";
     }
   }
 
@@ -156,14 +165,14 @@
    */
   function getSummaryTemplate(summaryOption, customTemplate) {
     switch (summaryOption) {
-      case 'blank':
-        return '';
-      case 'orig':
-        return '${summary}';
-      case 'custom':
+      case "blank":
+        return "";
+      case "orig":
+        return "${summary}";
+      case "custom":
         return customTemplate;
       default:
-        return '${blocksummary}Podfic of ${title} by ${authors}.';
+        return "${blocksummary}Podfic of ${title} by ${authors}.";
     }
   }
 
@@ -173,12 +182,12 @@
    * @param value {string}
    */
   function setTagsInputValue(inputElement, value) {
-    const event = new InputEvent('input', {bubbles: true, data: value});
+    const event = new InputEvent("input", { bubbles: true, data: value });
     inputElement.value = value;
     // Replicates the value changing.
     inputElement.dispatchEvent(event);
     // Replicates the user hitting comma.
-    inputElement.dispatchEvent(new KeyboardEvent('keydown', {'key': ','}));
+    inputElement.dispatchEvent(new KeyboardEvent("keydown", { key: "," }));
   }
 
   /**
@@ -187,7 +196,7 @@
    */
   function sanitizeSummary(summary) {
     if (!summary) {
-      return '';
+      return "";
     }
     // An opening <p> tag (shouldn't have attributes,
     // but even if it does we can still strip it)
@@ -195,10 +204,11 @@
     // A closing </p> tag
     const pClose = /\s*<\/p>\s*/g;
     const atats = /@@@+/g;
-    return summary.innerHTML.replace(pOpen, '@@@')
-        .replace(pClose, '@@@')
-        .replace(atats, '\n\n')
-        .trim();
+    return summary.innerHTML
+      .replace(pOpen, "@@@")
+      .replace(pClose, "@@@")
+      .replace(atats, "\n\n")
+      .trim();
   }
 
   /**
@@ -208,21 +218,21 @@
    * @returns {Array<[string,string]>}
    */
   function mapAuthors(authors) {
-    return Array.from(authors
-                          .reduce(
-                              (total, authorLink) => {
-                                // Check that this is actually a link to an
-                                // author--it could be a giftee.
-                                if (authorLink.getAttribute('rel') ==
-                                    'author') {
-                                  total.set(
-                                      authorLink.innerText.trim(),
-                                      authorLink.getAttribute('href'));
-                                }
-                                return total;
-                              },
-                              new Map())
-                          .entries());
+    return Array.from(
+      authors
+        .reduce((total, authorLink) => {
+          // Check that this is actually a link to an
+          // author--it could be a giftee.
+          if (authorLink.getAttribute("rel") == "author") {
+            total.set(
+              authorLink.innerText.trim(),
+              authorLink.getAttribute("href")
+            );
+          }
+          return total;
+        }, new Map())
+        .entries()
+    );
   }
 
   /**
@@ -231,33 +241,43 @@
    * @returns
    */
   function parseGenMetadata(doc) {
-    const meta = queryElement(doc, '.meta');
-    const rating = queryElement(meta, 'dd.rating.tags').innerText.trim();
-    const warnings = queryElements(queryElement(meta, 'dd.warning.tags'), 'a')
-                         .map(a => a.innerText.trim());
-    const relationships =
-        queryElements(queryElement(meta, 'dd.relationship.tags'), 'a')
-            .map(a => a.innerText.trim());
-    const characters =
-        queryElements(queryElement(meta, 'dd.character.tags'), 'a')
-            .map(a => a.innerText.trim());
-    const categories =
-        queryElements(queryElement(meta, 'dd.category.tags'), 'a')
-            .map(a => a.innerText.trim());
-    const fandoms = queryElements(queryElement(meta, 'dd.fandom.tags'), 'a')
-                        .map(a => a.innerText.trim());
-    const freeformTags =
-        queryElements(queryElement(meta, 'dd.freeform.tags'), 'a')
-            .map(a => a.innerText.trim());
-    const language = queryElement(meta, 'dd.language').innerText.trim();
+    const meta = queryElement(doc, ".meta");
+    const rating = queryElement(meta, "dd.rating.tags").innerText.trim();
+    const warnings = queryElements(
+      queryElement(meta, "dd.warning.tags"),
+      "a"
+    ).map((a) => a.innerText.trim());
+    const relationships = queryElements(
+      queryElement(meta, "dd.relationship.tags"),
+      "a"
+    ).map((a) => a.innerText.trim());
+    const characters = queryElements(
+      queryElement(meta, "dd.character.tags"),
+      "a"
+    ).map((a) => a.innerText.trim());
+    const categories = queryElements(
+      queryElement(meta, "dd.category.tags"),
+      "a"
+    ).map((a) => a.innerText.trim());
+    const fandoms = queryElements(
+      queryElement(meta, "dd.fandom.tags"),
+      "a"
+    ).map((a) => a.innerText.trim());
+    const freeformTags = queryElements(
+      queryElement(meta, "dd.freeform.tags"),
+      "a"
+    ).map((a) => a.innerText.trim());
+    const language = queryElement(meta, "dd.language").innerText.trim();
 
-    const work = doc.getElementById('workskin');
-    const title = queryElement(work, 'h2.title').innerText.trim();
-    const authors =
-        mapAuthors(queryElements(queryElement(work, '.byline'), 'a'));
+    const work = doc.getElementById("workskin");
+    const title = queryElement(work, "h2.title").innerText.trim();
+    const authors = mapAuthors(
+      queryElements(queryElement(work, ".byline"), "a")
+    );
     // The actual html of the summary, with <p>s replaced.
     const summary = sanitizeSummary(
-        queryElement(queryElement(work, 'div.summary.module'), '.userstuff'));
+      queryElement(queryElement(work, "div.summary.module"), ".userstuff")
+    );
 
     return {
       title,
@@ -285,33 +305,32 @@
     try {
       fetchUrl = new URL(url);
     } catch (e) {
-      return {result: 'error', message: `Invalid work URL: ${e.message}`};
+      return { result: "error", message: `Invalid work URL: ${e.message}` };
     }
     // Always consent to seeing "adult content" to simplifying parsing
-    fetchUrl.searchParams.set('view_adult', 'true');
+    fetchUrl.searchParams.set("view_adult", "true");
     // Initially try to get the work without credentials, this handles cases
     // where the user has tags or warnings hidden but can fail if the work
     // the user is importing from is only available to logged-in users.
     let result;
     try {
-      result = await window.fetch(fetchUrl, {credentials: 'omit'});
+      result = await window.fetch(fetchUrl, { credentials: "omit" });
     } catch (e) {
       return {
-        result: 'error',
-        message: `Failed to fetch the work! ${e.message}`
+        result: "error",
+        message: `Failed to fetch the work! ${e.message}`,
       };
     }
     if (!result.ok) {
       return {
-        result: 'error',
-        message: `Failed to fetch the work! Error: ${result.status} ${
-            result.statusText}`
+        result: "error",
+        message: `Failed to fetch the work! Error: ${result.status} ${result.statusText}`,
       };
     }
 
     const domParser = new DOMParser();
     let html = await result.text();
-    let doc = domParser.parseFromString(html, 'text/html');
+    let doc = domParser.parseFromString(html, "text/html");
 
     // If we end up in this case it means that the work was not available to
     // logged out users so we will attempt the fetch again but this time we will
@@ -319,85 +338,98 @@
     // then there will be errors later on but these are handled.
     if (result.redirected || looksLikeUnrevealedWork(doc)) {
       try {
-        result = await window.fetch(fetchUrl, {credentials: 'include'});
+        result = await window.fetch(fetchUrl, { credentials: "include" });
       } catch (e) {
         return {
-          result: 'error',
-          message: `Failed to fetch the work! ${e.message}`
+          result: "error",
+          message: `Failed to fetch the work! ${e.message}`,
         };
       }
       if (!result.ok) {
         return {
-          result: 'error',
-          message: `Failed to fetch the work! Error: ${result.status} ${
-              result.statusText}`
+          result: "error",
+          message: `Failed to fetch the work! Error: ${result.status} ${result.statusText}`,
         };
       }
       html = await result.text();
-      doc = domParser.parseFromString(html, 'text/html');
+      doc = domParser.parseFromString(html, "text/html");
 
       if (looksLikeUnrevealedWork(doc)) {
         return {
-          result: 'error',
+          result: "error",
           message:
-              'The selected work appears to be unrevealed please contact ' +
-              'the work author to get permission to view the work then try ' +
-              'again',
+            "The selected work appears to be unrevealed please contact " +
+            "the work author to get permission to view the work then try " +
+            "again",
         };
       }
     }
 
     return {
-      result: 'success',
+      result: "success",
       // We return back the original URL so that storage only ever contains
       // the URL the user input instead of the one we used for fetching.
-      metadata: {...parseGenMetadata(doc), url},
+      metadata: { ...parseGenMetadata(doc), url },
     };
   }
 
   function looksLikeUnrevealedWork(/** @type {Document} */ doc) {
     // The page has a notice saying that the work is yet to be revealed, and
     // there is no user content.
-    return Array.from(doc.querySelectorAll('p.notice'))
-               .some(
-                   notice => notice.textContent.includes(
-                       'This work is part of an ongoing challenge and will ' +
-                       'be revealed soon')) &&
-        !doc.querySelector('.userstuff');
+    return (
+      Array.from(doc.querySelectorAll("p.notice")).some((notice) =>
+        notice.textContent.includes(
+          "This work is part of an ongoing challenge and will " +
+            "be revealed soon"
+        )
+      ) && !doc.querySelector(".userstuff")
+    );
   }
 
   async function importAndFillMetadata() {
     let showPartialCompletionWarning = false;
-    const {options, workbody, summary_template, title_template} =
-        await browser.storage.sync.get(
-            ['options', 'workbody', 'summary_template', 'title_template']);
+    const {
+      options,
+      workbody,
+      summary_template,
+      title_template,
+      notes_template,
+    } = await browser.storage.sync.get([
+      "options",
+      "workbody",
+      "summary_template",
+      "title_template",
+      "notes_template",
+    ]);
 
-    const importResult = await importMetadata(options['url']);
+    const importResult = await importMetadata(options["url"]);
 
-    if (importResult.result === 'error') {
+    if (importResult.result === "error") {
       // Tell the popup that the import failed and the reason why it failed.
       browser.runtime.sendMessage(importResult);
       return;
     }
     const metadata = importResult.metadata;
 
-    const newWorkPage = document.getElementById('main');
+    const newWorkPage = document.getElementById("main");
 
     // Find the rating drop down, and pick the correct value.
-    const ratingSelect = queryElement(newWorkPage, '#work_rating_string');
+    const ratingSelect = queryElement(newWorkPage, "#work_rating_string");
     const ratingOptions = mapOptions(ratingSelect);
-    ratingSelect.value = ratingOptions.get(metadata['rating']);
+    ratingSelect.value = ratingOptions.get(metadata["rating"]);
 
     // Find the warning check boxes, and check all the ones that apply.
     const warningBoxes = mapInputs(
-        queryElements(queryElement(newWorkPage, 'fieldset.warnings'), 'input'));
+      queryElements(queryElement(newWorkPage, "fieldset.warnings"), "input")
+    );
     warningBoxes.set(
-        'Creator Chose Not To Use Archive Warnings',
-        warningBoxes.get('Choose Not To Use Archive Warnings'));
+      "Creator Chose Not To Use Archive Warnings",
+      warningBoxes.get("Choose Not To Use Archive Warnings")
+    );
     // Somehow it is possible for the imported metadata to have different
     // warnings than new work form. In this case we just ignore the warning
     // we failed to map.
-    for (const warning of metadata['warnings']) {
+    for (const warning of metadata["warnings"]) {
       if (warningBoxes.has(warning)) {
         warningBoxes.get(warning).checked = true;
       } else {
@@ -407,17 +439,20 @@
 
     // Find the fandom text input, and insert a comma-separated list of
     // fandoms. Tell ao3 we did so.
-    const fandomInput =
-        queryElement(queryElement(newWorkPage, 'dd.fandom'), 'input');
-    setTagsInputValue(fandomInput, metadata['fandoms'].join(', '));
+    const fandomInput = queryElement(
+      queryElement(newWorkPage, "dd.fandom"),
+      "input"
+    );
+    setTagsInputValue(fandomInput, metadata["fandoms"].join(", "));
 
     // Find the category check boxes, and check all the ones that apply.
     const categoryBoxes = mapInputs(
-        queryElements(queryElement(newWorkPage, 'dd.category'), 'input'));
+      queryElements(queryElement(newWorkPage, "dd.category"), "input")
+    );
     // Somehow it is possible for the imported metadata to have different
     // categories than new work form. In this case we just ignore the warning
     // we failed to map.
-    for (const category of metadata['categories']) {
+    for (const category of metadata["categories"]) {
       if (categoryBoxes.has(category)) {
         categoryBoxes.get(category).checked = true;
       } else {
@@ -427,80 +462,143 @@
 
     // Find the relationship text input, and insert a comma-separated list
     // of relationships. Tell ao3 we did so.
-    const relationshipInput =
-        queryElement(queryElement(newWorkPage, 'dd.relationship'), 'input');
-    setTagsInputValue(relationshipInput, metadata['relationships'].join(', '));
+    const relationshipInput = queryElement(
+      queryElement(newWorkPage, "dd.relationship"),
+      "input"
+    );
+    setTagsInputValue(relationshipInput, metadata["relationships"].join(", "));
 
     // Find the character input, and insert a comma-separated list of
     // characters. Tell ao3 we did so.
-    const characterInput =
-        queryElement(queryElement(newWorkPage, 'dd.character'), 'input');
-    setTagsInputValue(characterInput, metadata['characters'].join(', '));
+    const characterInput = queryElement(
+      queryElement(newWorkPage, "dd.character"),
+      "input"
+    );
+    setTagsInputValue(characterInput, metadata["characters"].join(", "));
 
     // Find the freeform tags input, and insert a comma-separated list of
     // freeform tags. (potentially auto-adding "Podfic" and "Podfic
     // Length" tags) Tell ao3 we did so.
-    const additionalTagsInput =
-        queryElement(queryElement(newWorkPage, 'dd.freeform'), 'input');
-    if (options['podfic_label']) {
-      metadata['freeformTags'].push('Podfic');
+    const additionalTagsInput = queryElement(
+      queryElement(newWorkPage, "dd.freeform"),
+      "input"
+    );
+    if (options["podfic_label"]) {
+      metadata["freeformTags"].push("Podfic");
     }
-    if (options['podfic_length_label']) {
-      metadata['freeformTags'].push(
-          'Podfic Length: ' + options['podfic_length_value']);
+    if (options["podfic_length_label"]) {
+      metadata["freeformTags"].push(
+        "Podfic Length: " + options["podfic_length_value"]
+      );
     }
-    setTagsInputValue(additionalTagsInput, metadata['freeformTags'].join(', '));
+    setTagsInputValue(additionalTagsInput, metadata["freeformTags"].join(", "));
 
     // Set the title.
-    const titleInput =
-        queryElement(queryElement(newWorkPage, 'dd.title'), 'input');
-    const titleTemplate =
-        getTitleTemplate(options['title_format'], title_template['default']);
+    const titleInput = queryElement(
+      queryElement(newWorkPage, "dd.title"),
+      "input"
+    );
+    const titleTemplate = getTitleTemplate(
+      options["title_format"],
+      title_template["default"]
+    );
     titleInput.value = transformTitle(
-        titleTemplate, metadata['title'], new Map(metadata['authors']));
+      titleTemplate,
+      metadata["title"],
+      new Map(metadata["authors"])
+    );
 
     // Set the summary, optionally wrapping it in a block quote.
-    const summaryTextArea =
-        queryElement(queryElement(newWorkPage, 'dd.summary'), 'textarea');
+    const summaryTextArea = queryElement(
+      queryElement(newWorkPage, "dd.summary"),
+      "textarea"
+    );
     const summaryTemplate = getSummaryTemplate(
-        options['summary_format'], summary_template['default']);
-    summaryTextArea.value = transformSummary(
-        summaryTemplate, metadata['summary'], metadata['title'],
-        metadata['url'], new Map(metadata['authors']));
+      options["summary_format"],
+      summary_template["default"]
+    );
+    const authorMap = new Map(metadata["authors"]);
+    summaryTextArea.value = transformHtmlTemplate(
+      summaryTemplate,
+      metadata["summary"],
+      metadata["title"],
+      metadata["url"],
+      authorMap
+    );
+
+    const notesTemplate = transformHtmlTemplate(
+      notes_template["default"],
+      metadata["summary"],
+      metadata["title"],
+      metadata["url"],
+      authorMap
+    );
+    if (notes_template["begin"]) {
+      const beginNotesCheckmark = queryElement(
+        newWorkPage,
+        "#front-notes-options-show"
+      );
+      if (!beginNotesCheckmark.checked) {
+        beginNotesCheckmark.click();
+      }
+      const beginNotesTextArea = queryElement(newWorkPage, "#work_notes");
+      beginNotesTextArea.value = notesTemplate;
+    }
+    if (notes_template["end"]) {
+      const endNotesCheckmark = queryElement(
+        newWorkPage,
+        "#end-notes-options-show"
+      );
+      if (!endNotesCheckmark.checked) {
+        endNotesCheckmark.click();
+      }
+      const endNotesTextArea = queryElement(newWorkPage, "#work_endnotes");
+      endNotesTextArea.value = notesTemplate;
+    }
 
     // Set the "inspired by" work url.
-    const parentCheckmark =
-        queryElement(queryElement(newWorkPage, 'dt.parent'), 'input');
+    const parentCheckmark = queryElement(
+      queryElement(newWorkPage, "dt.parent"),
+      "input"
+    );
     if (!parentCheckmark.checked) {
       parentCheckmark.click();
     }
     const parentUrl = queryElement(
-        newWorkPage, '#work_parent_work_relationships_attributes_0_url');
-    parentUrl.value = metadata['url'];
+      newWorkPage,
+      "#work_parent_work_relationships_attributes_0_url"
+    );
+    parentUrl.value = metadata["url"];
 
     // Set the same language as the original work.
-    const languageSelect = queryElement(newWorkPage, '#work_language_id');
+    const languageSelect = queryElement(newWorkPage, "#work_language_id");
     const languageOptions = mapOptions(languageSelect);
-    languageSelect.value = languageOptions.get(metadata['language']);
+    languageSelect.value = languageOptions.get(metadata["language"]);
 
     // Set the new work text.
-    const workText = queryElement(newWorkPage, '.mce-editor');
+    const workText = queryElement(newWorkPage, ".mce-editor");
     // If there's nothing here yet, over-write it.
-    if (workText.value == '') {
-      workText.value = workbody['default'];
+    if (workText.value == "") {
+      workText.value = transformHtmlTemplate(
+        workbody["default"],
+        metadata["summary"],
+        metadata["title"],
+        metadata["url"],
+        authorMap
+      );
     }
 
     if (showPartialCompletionWarning) {
       browser.runtime.sendMessage({
-        result: 'error',
+        result: "error",
         message:
-            'Warning: some data could not be imported, the most likely reason' +
-            'is that you set your AO3 preferences to hide warnings or tags',
+          "Warning: some data could not be imported, the most likely reason" +
+          "is that you set your AO3 preferences to hide warnings or tags",
       });
     } else {
       // Tell the popup that the import worked as expected.
       browser.runtime.sendMessage({
-        result: 'success',
+        result: "success",
       });
     }
   }

--- a/src/options.html
+++ b/src/options.html
@@ -100,28 +100,45 @@
             </form>
         </section>
         <section>
+            <div class="mdc-card mdc-card--outlined">
+                <header>
+                    <h1 class="mdc-typography--subtitle1">Common template keywords</h1>
+                </header>
+                <p>
+                    These template keywords are shared between all templates that support html, which means summary, notes, and work body, but not the custom title template.
+                </p>
+                <p>
+                    The following sequences in your templates will be replaced:
+                </p>
+                <dl>
+                    <dt><strong><code>${blocksummary}</code></strong></dt>
+                    <dd>The summary of the original work wrapped in a <code>blockquote</code>, which will indent it. Because of
+                        the way ao3 handles block quotes, you should put whatever you want to
+                        follow this on the same line.</dd>
+                    <dt><strong><code>${summary}</code></strong></dt>
+                    <dd>The summary of the original work.</dd>
+                    <dt><strong><code>${title}</code></strong></dt>
+                    <dd>The title of the original work. This will be a link to the original work.</dd>
+                    <dt><strong><code>${title-unlinked}</code></strong></dt>
+                    <dd>The title of the original work, without a link to the original work.</dd>
+                    <dt><strong><code>${authors}</code></strong></dt>
+                    <dd>A comma-separated list of the authors of the original work. Each author is a link
+                        to their AO3 page.</dd>
+                    <dt><strong><code>${authors-unlinked}</code></strong></dt>
+                    <dd>A comma-separated list of the authors of the original work, without links
+                        to their AO3 page.</dd>
+                </dl>
+            </div>
+        </section>
+        <section>
             <form id="summary_form">
                 <div class="mdc-card mdc-card--outlined">
                     <header>
                         <h1 class="mdc-typography--subtitle1">Custom summary template</h1>
                     </header>
                     <p>
-                        Set the summary template to use with the "Custom" summary format option.<br>
-                        The following sequences in your template will be replaced:
+                        Set the summary template to use with the "Custom" summary format option.
                     </p>
-                    <dl>
-                        <dt><strong><code>${blocksummary}</code></strong></dt>
-                        <dd>The summary of the original work wrapped in a <code>blockquote</code>. Because of
-                            the way ao3 handles block quotes, you should put whatever you want to
-                            follow this on the same line.</dd>
-                        <dt><strong><code>${summary}</code></strong></dt>
-                        <dd>The summary of the original work.</dd>
-                        <dt><strong><code>${title}</code></strong></dt>
-                        <dd>The title of the original work. This will be a link to the original work.</dd>
-                        <dt><strong><code>${authors}</code></strong></dt>
-                        <dd>A comma-separated list of the authors of the original work. Each author is a link
-                            to their AO3 page.</dd>
-                    </dl>
                     <p>
                         This template supports HTML.
                         <a href="https://archiveofourown.org/faq/formatting-content-on-ao3-with-html?language_id=en#canihtml"
@@ -166,15 +183,96 @@
             </form>
         </section>
         <section>
+            <form id="notes_form">
+                <div class="mdc-card mdc-card--outlined">
+                    <header>
+                        <h1 class="mdc-typography--subtitle1">Custom notes template</h1>
+                    </header>
+                    <p>
+                        Set the template to use for beginning and/or end notes.
+                    </p>
+                    <p>
+                        This template supports HTML.
+                        <a href="https://archiveofourown.org/faq/formatting-content-on-ao3-with-html?language_id=en#canihtml"
+                            target="_blank">Learn more about using HTML on AO3</a>
+                    </p><div class="form-item">
+                        <div class="mdc-form-field" data-mdc-auto-init="MDCFormField">
+                            <div class="mdc-checkbox" data-mdc-auto-init="MDCCheckbox">
+                                <input type="checkbox" class="mdc-checkbox__native-control" id="beginning_notes" />
+                                <div class="mdc-checkbox__background">
+                                    <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                                        <path class="mdc-checkbox__checkmark-path" fill="none"
+                                            d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                                    </svg>
+                                    <div class="mdc-checkbox__mixedmark"></div>
+                                </div>
+                                <div class="mdc-checkbox__ripple"></div>
+                            </div>
+                            <label for="beginning_notes">Use as beginning notes</label>
+                        </div>
+                    </div>
+                    <div class="form-item">
+                        <div class="mdc-form-field" data-mdc-auto-init="MDCFormField">
+                            <div class="mdc-checkbox" data-mdc-auto-init="MDCCheckbox">
+                                <input type="checkbox" class="mdc-checkbox__native-control" id="end_notes" />
+                                <div class="mdc-checkbox__background">
+                                    <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                                        <path class="mdc-checkbox__checkmark-path" fill="none"
+                                            d="M1.73,12.91 8.1,19.28 22.79,4.59" />
+                                    </svg>
+                                    <div class="mdc-checkbox__mixedmark"></div>
+                                </div>
+                                <div class="mdc-checkbox__ripple"></div>
+                            </div>
+                            <label for="end_notes">Use as end notes</label>
+                        </div>
+                    </div>                                        
+                    <label class="mdc-text-field mdc-text-field--filled mdc-text-field--textarea"
+                        data-mdc-auto-init="MDCTextField">
+                        <span class="mdc-text-field__ripple"></span>
+                        <span class="mdc-floating-label" id="notes_template_label">Notes template</span>
+                        <span class="mdc-text-field__resizer">
+                            <textarea class="mdc-text-field__input code-editor-textarea" rows="5" cols="100"
+                                aria-labelledby="notes_template_label" id="notes_template" required
+                                spellcheck="false"></textarea>
+                        </span>
+                        <span class="mdc-line-ripple"></span>
+                    </label>
+                    <div class="mdc-text-field-helper-line">
+                        <div class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg"
+                            aria-hidden="true">
+                        </div>
+                    </div>
+                    <h2 class="mdc-typography--subtitle2">Preview of generated HTML</h2>
+                    <pre>
+                        <code id="notes_preview" class="language-html"></code>
+                    </pre>
+                    <div class="mdc-card__actions actions">
+                        <button class="mdc-button mdc-button--raised mdc-card__action" type="submit"
+                            data-mdc-auto-init="MDCRipple">
+                            <div class="mdc-button__ripple"></div>
+                            <i class="material-icons mdc-button__icon" aria-hidden="true">save</i>
+                            <span class="mdc-button__label">Save</span>
+                        </button>
+                        <button id="notes_reset"
+                            class="mdc-button mdc-button--outlined mdc-button--icon-leading mdc-card__action"
+                            type="reset" data-mdc-auto-init="MDCRipple">
+                            <div class="mdc-button__ripple"></div>
+                            <i class="material-icons mdc-button__icon" aria-hidden="true">restart_alt</i>
+                            <span class="mdc-button__label">Reset to default</span>
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </section>
+        <section>
             <form id="work_form">
                 <div class="mdc-card mdc-card--outlined">
                     <header>
                         <h1 class="mdc-typography--subtitle1">Work template</h1>
                     </header>
                     <p>
-                        Set the default work template for your work: (this won't replace
-                        any metadata for you, but at least you won't have to go find
-                        wherever you have this saved for yourself).
+                        Set the default work template for your work.
                     </p>
                     <p>
                         Note: this will leave the body of your work alone if your draft

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,4 @@
-import {setInputValue, setupStorage} from './utils.js';
-
+import { setCheckboxState, setInputValue, setupStorage } from "./utils.js";
 
 (async () => {
   await setupStorage();
@@ -23,6 +22,7 @@ import {setInputValue, setupStorage} from './utils.js';
     "colgroup",
     "dd",
     "del",
+    "details",
     "dfn",
     "div",
     "dl",
@@ -52,6 +52,7 @@ import {setInputValue, setupStorage} from './utils.js';
     "strike",
     "strong",
     "sub",
+    "summary",
     "sup",
     "table",
     "tbody",
@@ -69,76 +70,99 @@ import {setInputValue, setupStorage} from './utils.js';
   });
 
   // AO3 does not allow styles
-  HtmlSanitizer.AllowedAttributes['style'] = false;
-  HtmlSanitizer.AllowedAttributes['rel'] = true;
-  HtmlSanitizer.AllowedAttributes['alt'] = true;
-  HtmlSanitizer.AllowedAttributes['crossorigin'] = true;
-  HtmlSanitizer.AllowedAttributes['preload'] = true;
+  HtmlSanitizer.AllowedAttributes["style"] = false;
+  HtmlSanitizer.AllowedAttributes["rel"] = true;
+  HtmlSanitizer.AllowedAttributes["alt"] = true;
+  HtmlSanitizer.AllowedAttributes["crossorigin"] = true;
+  HtmlSanitizer.AllowedAttributes["preload"] = true;
 
   const DOM_PARSER = new DOMParser();
 
   hljs.highlightAll();
 
   /** @type {HTMLInputElement} */
-  const titleTemplate = document.getElementById('title_template');
+  const titleTemplate = document.getElementById("title_template");
   /** @type {HTMLFormElement} */
-  const titleForm = document.getElementById('title_form');
+  const titleForm = document.getElementById("title_form");
   /** @type {HTMLInputElement} */
-  const titlePreview = document.getElementById('title_preview');
+  const titlePreview = document.getElementById("title_preview");
   /** @type {MDCTextField} */
-  const titleTextField = titleTemplate.closest('.mdc-text-field').MDCTextField;
+  const titleTextField = titleTemplate.closest(".mdc-text-field").MDCTextField;
   /** @type {HTMLInputElement} */
-  const summaryTemplate = document.getElementById('summary_template');
+  const summaryTemplate = document.getElementById("summary_template");
   const summaryTemplateTextField =
-      summaryTemplate.closest('.mdc-text-field').MDCTextField;
+    summaryTemplate.closest(".mdc-text-field").MDCTextField;
   /** @type {HTMLElement} */
-  const summaryPreview = document.getElementById('summary_preview');
+  const summaryPreview = document.getElementById("summary_preview");
   /** @type {HTMLFormElement} */
-  const summaryForm = document.getElementById('summary_form');
+  const summaryForm = document.getElementById("summary_form");
+  const notesTemplate = document.getElementById("notes_template");
+  const notesTemplateTextField =
+    notesTemplate.closest(".mdc-text-field").MDCTextField;
+  /** @type {HTMLElement} */
+  const notesPreview = document.getElementById("notes_preview");
+  /** @type {HTMLFormElement} */
+  const notesForm = document.getElementById("notes_form");
   /** @type {HTMLInputElement} */
-  const defaultBody = document.getElementById('default_body');
+  const defaultBody = document.getElementById("default_body");
   const defaultBodyTextField =
-      defaultBody.closest('.mdc-text-field').MDCTextField;
+    defaultBody.closest(".mdc-text-field").MDCTextField;
   /** @type {HTMLElement} */
-  const defaultBodyPreview = document.getElementById('default_body_preview');
+  const defaultBodyPreview = document.getElementById("default_body_preview");
   /** @type {HTMLFormElement} */
-  const workForm = document.getElementById('work_form');
-  const snackbar = document.querySelector('.mdc-snackbar').MDCSnackbar;
+  const workForm = document.getElementById("work_form");
+  const snackbar = document.querySelector(".mdc-snackbar").MDCSnackbar;
   /** @type {HTMLButtonElement} */
-  const titleResetButton = document.getElementById('title_reset');
+  const titleResetButton = document.getElementById("title_reset");
   /** @type {HTMLButtonElement} */
-  const summaryResetButton = document.getElementById('summary_reset');
+  const summaryResetButton = document.getElementById("summary_reset");
+  /** @type {HTMLButtonElement} */
+  const notesResetButton = document.getElementById("notes_reset");
+  /** @type {HTMLInputElement} */
+  const beginningNotesCheckbox = document.getElementById("beginning_notes");
+  /** @type {HTMLInputElement} */
+  const endNotesCheckbox = document.getElementById("end_notes");
 
-  titleResetButton.addEventListener(
-      'click', (async () => {
-        const {title_template} =
-            await browser.storage.sync.get('title_template');
-        setInputValue(titleTemplate, '[Podfic] ${title}');
-      }));
+  titleResetButton.addEventListener("click", async () => {
+    const { title_template } = await browser.storage.sync.get("title_template");
+    setInputValue(titleTemplate, "[Podfic] ${title}");
+  });
 
-  summaryResetButton.addEventListener(
-      'click', (async () => {
-        const {summary_template} =
-            await browser.storage.sync.get('summary_template');
-        setInputValue(
-            summaryTemplate,
-            '${blocksummary}Podfic of ${title} by ${authors}.');
-      }));
+  summaryResetButton.addEventListener("click", async () => {
+    const { summary_template } = await browser.storage.sync.get(
+      "summary_template"
+    );
+    setInputValue(
+      summaryTemplate,
+      "${blocksummary}Podfic of ${title} by ${authors}."
+    );
+  });
+
+  notesResetButton.addEventListener("click", async () => {
+    const { notes_template } = await browser.storage.sync.get("notes_template");
+
+    setInputValue(notesTemplate, "");
+    setCheckboxState(beginningNotesCheckbox, false);
+    setCheckboxState(endNotesCheckbox, false);
+  });
 
   titleTextField.useNativeValidation = false;
 
-  titleTemplate.addEventListener('input', event => {
-    titlePreview.textContent =
-        event.target.value.replaceAll('${title}', 'TITLE_TEXT')
-            .replaceAll('${authors}', 'AUTHOR_1, AUTHOR_2')
-            .replaceAll('${author}', 'AUTHOR_1');
+  titleTemplate.addEventListener("input", (event) => {
+    titlePreview.textContent = event.target.value
+      .replaceAll("${title}", "TITLE_TEXT")
+      .replaceAll("${title-unlinked}", "TITLE_TEXT")
+      .replaceAll("${authors}", "AUTHOR_1, AUTHOR_2")
+      .replaceAll("${author}", "AUTHOR_1, AUTHOR_2")
+      .replaceAll("${authors-unlinked}", "AUTHOR_1, AUTHOR_2")
+      .replaceAll("${author-unlinked}", "AUTHOR_1, AUTHOR_2");
     hljs.highlightElement(titlePreview);
     if (isHtml(event.target.value)) {
       titleTextField.helperTextContent =
-          'This template should not contain HTML but it appears to contain HTML';
+        "This template should not contain HTML but it appears to contain HTML";
       titleTextField.valid = false;
     } else {
-      titleTextField.helperTextContent = '';
+      titleTextField.helperTextContent = "";
       titleTextField.valid = true;
     }
   });
@@ -147,94 +171,129 @@ import {setInputValue, setupStorage} from './utils.js';
     return /<\/?[a-z][\s\S]*>/i.test(str);
   }
 
-  summaryTemplateTextField.useNativeValidation = false;
+  attachHTMLPreviewAndValidateListeners(
+    summaryTemplateTextField,
+    summaryTemplate,
+    summaryPreview
+  );
 
-  summaryTemplate.addEventListener('input', event => {
-    const summaryPreviewHtml = HtmlSanitizer.SanitizeHtml(
+  attachHTMLPreviewAndValidateListeners(
+    notesTemplateTextField,
+    notesTemplate,
+    notesPreview
+  );
+
+  attachHTMLPreviewAndValidateListeners(
+    defaultBodyTextField,
+    defaultBody,
+    defaultBodyPreview
+  );
+
+  function attachHTMLPreviewAndValidateListeners(
+    /** @type{MDCTextField}*/ templateTextField,
+    /** @type{HTMLInputElement}*/ template,
+    /** @type{HTMLElement}*/ preview
+  ) {
+    templateTextField.useNativeValidation = false;
+
+    template.addEventListener("input", (event) => {
+      const previewHtml = HtmlSanitizer.SanitizeHtml(
         event.target.value
-            .replaceAll(
-                '${blocksummary}',
-                '<blockquote>BLOCK_SUMMARY_TEXT</blockquote>')
-            .replaceAll('${summary}', 'SUMMARY_TEXT')
-            .replaceAll('${title}', '<a>TITLE_TEXT</a>')
-            .replaceAll('${authors}', '<a>AUTHOR_1</a>, <a>AUTHOR_2</a>')
-            .replaceAll('${author}', '<a>AUTHOR_1</a>'));
+          .replaceAll(
+            "${blocksummary}",
+            "<blockquote>BLOCK_SUMMARY_TEXT</blockquote>"
+          )
+          .replaceAll("${summary}", "SUMMARY_TEXT")
+          .replaceAll("${title}", "<a>TITLE_TEXT</a>")
+          .replaceAll("${title-unlinked}", "TITLE_TEXT")
+          .replaceAll("${authors}", "<a>AUTHOR_1</a>, <a>AUTHOR_2</a>")
+          .replaceAll("${author}", "<a>AUTHOR_1</a>, <a>AUTHOR_2</a>")
+          .replaceAll("${authors-unlinked}", "AUTHOR_1, AUTHOR_2")
+          .replaceAll("${author-unlinked}", "AUTHOR_1, AUTHOR_2")
+      );
 
-    summaryPreview.textContent = summaryPreviewHtml;
-    hljs.highlightElement(summaryPreview);
+      preview.textContent = previewHtml;
+      hljs.highlightElement(preview);
 
-    if (!isValidAo3ValidHtml(event.target.value)) {
-      summaryTemplateTextField.helperTextContent =
-          'This template appears to contain HTML tags that cannot be used on ' +
-          'AO3, they have been removed from the preview';
-      summaryTemplateTextField.valid = false;
-    } else {
-      summaryTemplateTextField.helperTextContent = '';
-      summaryTemplateTextField.valid = true;
-    }
-  });
-
-  defaultBodyTextField.useNativeValidation = false;
-
-  defaultBody.addEventListener('input', event => {
-    defaultBodyPreview.textContent =
-        HtmlSanitizer.SanitizeHtml(event.target.value);
-    hljs.highlightElement(defaultBodyPreview);
-
-    if (!isValidAo3ValidHtml(event.target.value)) {
-      defaultBodyTextField.helperTextContent =
-          'This template appears to contain HTML tags that cannot be used on ' +
-          'AO3, they have been removed from the preview';
-      defaultBodyTextField.valid = false;
-    } else {
-      defaultBodyTextField.helperTextContent = '';
-      defaultBodyTextField.valid = true;
-    }
-  });
-
+      if (!isValidAo3ValidHtml(event.target.value)) {
+        templateTextField.helperTextContent =
+          "This template appears to contain HTML tags that cannot be used on " +
+          "AO3, they have been removed from the preview";
+        templateTextField.valid = false;
+      } else {
+        templateTextField.helperTextContent = "";
+        templateTextField.valid = true;
+      }
+    });
+  }
 
   function isValidAo3ValidHtml(/** @type{string} */ html) {
     const sanitized = HtmlSanitizer.SanitizeHtml(html.trim());
-    const userDocument = DOM_PARSER.parseFromString(html.trim(), 'text/html');
-    const sanitizedDocument =
-        DOM_PARSER.parseFromString(sanitized, 'text/html');
-    return userDocument.documentElement.innerHTML ===
-        sanitizedDocument.documentElement.innerHTML;
+    const userDocument = DOM_PARSER.parseFromString(html.trim(), "text/html");
+    const sanitizedDocument = DOM_PARSER.parseFromString(
+      sanitized,
+      "text/html"
+    );
+    return (
+      userDocument.documentElement.innerHTML ===
+      sanitizedDocument.documentElement.innerHTML
+    );
   }
 
   // Import default body text from storage.
   (async () => {
-    const {title_template, summary_template, workbody} =
-        await browser.storage.sync.get(
-            ['title_template', 'summary_template', 'workbody']);
-    setInputValue(titleTemplate, title_template['default']);
-    setInputValue(defaultBody, workbody['default']);
-    setInputValue(summaryTemplate, summary_template['default']);
+    const { title_template, summary_template, notes_template, workbody } =
+      await browser.storage.sync.get([
+        "title_template",
+        "summary_template",
+        "notes_template",
+        "workbody",
+      ]);
+    setInputValue(titleTemplate, title_template["default"]);
+    setInputValue(defaultBody, workbody["default"]);
+    setInputValue(summaryTemplate, summary_template["default"]);
+    setInputValue(notesTemplate, notes_template["default"]);
+    setCheckboxState(beginningNotesCheckbox, notes_template["begin"]);
+    setCheckboxState(endNotesCheckbox, notes_template["end"]);
   })();
 
   // When the form is submitted, save the default body text (without overriding
   // other options).
-  workForm.addEventListener('submit', async submitEvent => {
+  workForm.addEventListener("submit", async (submitEvent) => {
     submitEvent.preventDefault();
-    await browser.storage.sync.set(
-        {'workbody': {'default': defaultBody.value}});
+    await browser.storage.sync.set({
+      workbody: { default: defaultBody.value },
+    });
     snackbar.open();
   });
-  titleForm.addEventListener('submit', async submitEvent => {
+  titleForm.addEventListener("submit", async (submitEvent) => {
     submitEvent.preventDefault();
-    await browser.storage.sync.set(
-        {'title_template': {'default': titleTemplate.value}});
+    await browser.storage.sync.set({
+      title_template: { default: titleTemplate.value },
+    });
     snackbar.open();
   });
-  summaryForm.addEventListener('submit', async submitEvent => {
+  summaryForm.addEventListener("submit", async (submitEvent) => {
     submitEvent.preventDefault();
-    await browser.storage.sync.set(
-        {'summary_template': {'default': summaryTemplate.value}});
+    await browser.storage.sync.set({
+      summary_template: { default: summaryTemplate.value },
+    });
+    snackbar.open();
+  });
+  notesForm.addEventListener("submit", async (submitEvent) => {
+    submitEvent.preventDefault();
+    await browser.storage.sync.set({
+      notes_template: {
+        default: notesTemplate.value,
+        begin: beginningNotesCheckbox.checked,
+        end: endNotesCheckbox.checked,
+      },
+    });
     snackbar.open();
   });
 
-  document.querySelector('.version').textContent =
-      browser.runtime.getManifest().version;
+  document.querySelector(".version").textContent =
+    browser.runtime.getManifest().version;
 
   // Set focus for a11y.
   titleTemplate.focus();

--- a/src/popup.html
+++ b/src/popup.html
@@ -373,7 +373,7 @@
                         </div>
                     </div>
                 </div>
-                <p> You can set custom title template, summary template, and work
+                <p> You can set custom title template, summary template, notes, and work
                     body text in the <a id="options_link_bottom" target="_blank">options page for
                     this extension</a> 
                 </p>


### PR DESCRIPTION
This combines a recent informal request for non-linked author/title templating, the filed issue for end notes, and an unfiled request from a while back for having templating in the work body.

Changes:
* Add ${title-unlinked} and ${authors-unlinked} as templating keywords
* Add a notes template that can be used for beginning notes, end notes, or both
* Add keyword replacement to the work body in addition to the new notes template
* Update options page to separate out templating keywords into a separate section