### PR TITLE
Fix importing from drafts.

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -331,7 +331,7 @@
     fetchUrl.searchParams.set('view_adult', 'true');
     let result;
     try {
-      result = await window.fetch(fetchUrl, {credentials: 'omit'});
+      result = await window.fetch(fetchUrl, {credentials});
     } catch (e) {
       return {
         result: 'error',

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/chrome-manifest",
   "name": "AO3 Podfic Posting Helper",
   "description": "Autofill metadata to match a work you were inspired by",
-  "version": "3.6",
+  "version": "3.7",
   "manifest_version": 3,
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
To make it easier to follow and hopefully harder to introduce bugs here in the future, I re-ordered the various fetch attempts to try to make the logic more straightforward:

1. try without credentials
2. if mystery (looks like mystery) or draft (redirected to login page), try with credentials
3. if redirected and looks like adult warning, retry new url with adult param (including or omitting credentials depending on whether we passed through (2))
4. If the most recent page we tried looks like a mystery or has a permission warning, tell the user to contact the author